### PR TITLE
feat: CLI tool now supports cd

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander';
 import { mkdirCommand } from './src/commands/mkdir.ts';
 import { lsCommand } from './src/commands/ls.ts';
+import { cdCommand } from './src/commands/cd.ts';
 
 const program = new Command();
 mkdirCommand(program);
 lsCommand(program);
+cdCommand(program);
 
 program.parse();
 

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import path from "path";
+
+export const cdCommand = (program: Command): void => {
+  program
+    .command("cd <path>")
+    .description("Change current directory")
+    .action((paths: string) => {
+      try {
+        const resolvedPath = paths.startsWith("/")
+          ? paths
+          : path.resolve(process.cwd(), paths);
+        process.chdir(resolvedPath);
+        console.log(`Current directory changed to: ${process.cwd()}`);
+      } catch (error) {
+        console.error(`Error changing directory: ${(error as Error).message}`);
+      }
+    });
+};


### PR DESCRIPTION
**Summary:**

This pull request enhances the CLI tool's navigation capabilities by introducing the `cd` command. Users can now effortlessly change working directories within the tool, streamlining their workflow and interactions.

**Key Features:**

- **Intuitive directory navigation:** Users can seamlessly switch between directories using the familiar `cd` command syntax.
- **Compatibility with existing commands:** The `cd` command integrates seamlessly with other commands in the tool, ensuring a cohesive experience.


